### PR TITLE
pull the scriptsbase image before executing the upgrade

### DIFF
--- a/deployKermit.sh
+++ b/deployKermit.sh
@@ -58,6 +58,7 @@ pull_images() {
   _exec_cmd "sudo docker pull $KWWW_IMG:$DEPLOY_VERSION"
   _exec_cmd "sudo docker pull $KAPI_IMG:$DEPLOY_VERSION"
   _exec_cmd "sudo docker pull $KMICRO_IMG:$DEPLOY_VERSION"
+  _exec_cmd "sudo docker pull $KSCRIPTSBASE_IMG:$DEPLOY_VERSION"
 
 }
 


### PR DESCRIPTION
#90

now that image is successfully pushed, we can add a pull without risking making the deploy fail.  The ENV is already added to the deploy_kermit runSh job.