### PR TITLE
micro indirectly triggers kermit now

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -677,7 +677,6 @@ jobs:
       - IN: installer_img
       - IN: kwww_img
       - IN: kapi_img
-      - IN: kmicro_img
       - IN: kscriptsbase_img
       - IN: rt_creds
         switch: off


### PR DESCRIPTION
since the flow goes micro->scriptsbase->deploy, we dont need micro->deploy anymore.  Keeping it is leading to some kind of race condition on kermit_deploy where it isn't deploying at all.