### PR TITLE
fixing the installer image build

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -682,8 +682,7 @@ jobs:
             - echo "Pushing $IMG_NAME:$REL_VER to Artifactory"
             - jfrog rt config --url "$RT_URL" --user "$RT_USER" --apikey "$RT_API_KEY" --interactive=false
             - echo "----------- Pushing image to installer repo ---------"
-            - docker tag $IMG_NAME:$REL_VER $RT_REGISTRY/installer:$REL_VER
-            - jfrog rt docker-push $RT_REGISTRY/installer:$REL_VER $RT_REGISTRY_KEY --build-name=$JOB_NAME --build-number=$BUILD_NUMBER
+            - jfrog rt docker-push $IMG_NAME:$REL_VER $RT_REGISTRY_KEY --build-name=$JOB_NAME --build-number=$BUILD_NUMBER
             - echo "----------- Gathering build info --------------------"
             - jfrog rt bag $JOB_NAME $BUILD_NUMBER
             - popd


### PR DESCRIPTION
https://app.shippable.com/github/Qhode/jobs/installer_build/builds/5d4010bbd5e22e0006e95b3c/console

The installer image we push is `pipelines-docker.jfrog.io/installer:master` & the installer image we require is `pipelines-docker.jfrog.io/jfrog/pipelines-installer:master`. I think something is wrong with the job.

Please merge if you think this is correct, else I will close the PR