### PR TITLE
#177; change reqExec sourceName.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -392,7 +392,7 @@ resources:
     type: gitRepo
     integration: "qhode_gh"
     pointer:
-      sourceName: "shippable/kermit-reqExec"
+      sourceName: "Shippable/kermit-reqExec"
       branch: master
 
 jobs:


### PR DESCRIPTION
#177 

This should cause rSync to recognize that the repository has changed, find out it's private, and add the presumably missing deploy key.